### PR TITLE
Allow overriding monit_include_dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ Or you can include just the role, and configure it in host vars file:
 
     monit_daemon: 30
 
+### `monit_include_dirs`
+
+A list of directories to include as `include` statements in monitrc
+
+Example:
+
+```
+monit_include_dirs:
+- /etc/monit.d
+```
 
 License
 -------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,6 +34,12 @@
          3 if 'This is Monit version 3.' in monit_version_result.stdout else
          None }}
 
+# Workaround https://github.com/ansible/ansible/issues/6756
+- name: Set default monit_include_dirs if not already set
+  set_fact:
+    monit_include_dirs: "{{__monit_include_dirs}}"
+  when: monit_include_dirs is not defined
+
 - name: monit conf
   sudo: True
   template: src=monitrc.j2 dest={{monit_conf}} owner=root

--- a/vars/CentOS-5.yml
+++ b/vars/CentOS-5.yml
@@ -1,5 +1,5 @@
 ---
 monit_conf: /etc/monit.conf
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 package_names: [ "monit" ]

--- a/vars/CentOS-6.yml
+++ b/vars/CentOS-6.yml
@@ -1,6 +1,6 @@
 ---
 monit_conf: /etc/monit.conf
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 monit_logfile: syslog
 package_names: [ "monit" ]

--- a/vars/CentOS-7.yml
+++ b/vars/CentOS-7.yml
@@ -1,6 +1,6 @@
 ---
 monit_conf: /etc/monitrc
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 monit_logfile: syslog
 package_names: [ "monit" ]

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@
 monit_conf: /etc/monit/monitrc
 monit_eventqueue_basedir: /var/lib/monit/events
 monit_idfile: /var/lib/monit/id
-monit_include_dirs: [ "/etc/monit/conf.d" ]
+__monit_include_dirs: [ "/etc/monit/conf.d" ]
 monit_logfile: /var/log/monit.log
 monit_statefile: /var/lib/monit/state
 package_names: [ "monit" ]

--- a/vars/RedHat-5.yml
+++ b/vars/RedHat-5.yml
@@ -1,5 +1,5 @@
 ---
 monit_conf: /etc/monit.conf
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 package_names: [ "monit" ]

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -1,6 +1,6 @@
 ---
 monit_conf: /etc/monit.conf
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 monit_logfile: syslog
 package_names: [ "monit" ]

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -1,6 +1,6 @@
 ---
 monit_conf: /etc/monitrc
 monit_eventqueue_basedir: /var/monit
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 monit_logfile: syslog
 package_names: [ "monit" ]

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,4 @@
 ---
 monit_conf: /etc/monit.conf
-monit_include_dirs: [ "/etc/monit.d" ]
+__monit_include_dirs: [ "/etc/monit.d" ]
 package_names: [ "monit" ]

--- a/vars/Ubuntu-16.yml
+++ b/vars/Ubuntu-16.yml
@@ -2,7 +2,7 @@
 monit_conf: /etc/monit/monitrc
 monit_eventqueue_basedir: /var/lib/monit/events
 monit_idfile: /var/lib/monit/id
-monit_include_dirs: [ "/etc/monit/conf.d", "/etc/monit/conf-enabled" ]
+__monit_include_dirs: [ "/etc/monit/conf.d", "/etc/monit/conf-enabled" ]
 monit_logfile: /var/log/monit.log
 monit_statefile: /var/lib/monit/state
 package_names: [ "monit" ]


### PR DESCRIPTION
Works around https://github.com/ansible/ansible/issues/6756